### PR TITLE
Feat: support for hyperlinks

### DIFF
--- a/src/Section.js
+++ b/src/Section.js
@@ -43,6 +43,9 @@ function Section({ ast, astState, page, rawText }) {
       case "text":
         return <Text key={i} {...o} />;
 
+      case "link":
+        return <a href={o.href}>{o.anchorText}</a>;
+
       case "statement":
         return (
           <span className="full-statement" key={i}>

--- a/src/smarter-text.js
+++ b/src/smarter-text.js
@@ -150,7 +150,7 @@ const docParser = P.createLanguage({
 
   Decimal: (r) => P.regexp(/[+-]?[0-9.]+/).map(explainDecimal),
 
-  Link: (r) => P.regexp(/\[([^\[\]]*)\]\((.*?)\)/).map(makeLink),
+  Link: (r) => P.regexp(/\[([^[\]]*)\]\((.*?)\)/).map(makeLink),
 
   Text: (r) =>
     P.alt(P.any, P.whitespace).map((x) => ({ type: "text", value: x })),

--- a/src/smarter-text.js
+++ b/src/smarter-text.js
@@ -86,13 +86,24 @@ function makeRange(parseResult) {
     };
   }
 }
+
+function makeLink(parseResult) {
+  const matches = parseResult.match(/\[(.*?)\]\((.*?)\)/);
+
+  return {
+    type: "link",
+    anchorText: matches[1],
+    href: matches[2],
+  };
+}
+
 const docParser = P.createLanguage({
   // The .many() is important -- we're parsing into an array of any
   // sequence of these Parser matches. The parser isn't expecting
   // that; it wants hierarchy. Without that, the parser fails and
   // says (most often) that it was expecting EOF.
 
-  Doc: (r) => P.alt(r.DecimalExpression, r.Statement, r.Text).many(),
+  Doc: (r) => P.alt(r.DecimalExpression, r.Statement, r.Link, r.Text).many(),
 
   Statement: (r) =>
     P.alt(r.DollarStatement, r.PercentageStatement, r.DecimalStatement),
@@ -138,6 +149,8 @@ const docParser = P.createLanguage({
   Math: (r) => P.regexp(/[^:]+/),
 
   Decimal: (r) => P.regexp(/[+-]?[0-9.]+/).map(explainDecimal),
+
+  Link: (r) => P.regexp(/\[([^\[\]]*)\]\((.*?)\)/).map(makeLink),
 
   Text: (r) =>
     P.alt(P.any, P.whitespace).map((x) => ({ type: "text", value: x })),


### PR DESCRIPTION
Hyperlink support added for Markdown style links - see #6 

For example, the parser will convert ``[Postlight Careers](https://postlight.com/careers)`` to:

```javascript
{
    type: "link",
    anchorText: "Postlight Careers",
    href: "https://postlight.com/careers"
}
```

which will be rendered as a simple ``<a>`` tag:
```html
<a href="https://postlight.com/careers">Postlight Careers</a>
```

 